### PR TITLE
Link for Example

### DIFF
--- a/src/domains/word/index.interface.ts
+++ b/src/domains/word/index.interface.ts
@@ -10,6 +10,7 @@ export interface IWord extends DataBasicsDate {
   pronunciation: string
   definition: string
   example: string
+  exampleLink: string
   tags: string[]
   dateAdded: number
 }

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -26,10 +26,10 @@ export class WordDomain extends DomainRoot {
   private constructor(props: Partial<IWord>) {
     super()
     if (!props.userId) throw new DataNotPresentError('User ID')
-
     this.props = props
-    props.tags = this.intoTrimmedAndUniqueArray(props.tags) // every tag must be trimmed/unique all the time
 
+    this.props.tags = this.intoTrimmedAndUniqueArray(props.tags) // every tag must be trimmed/unique all the time
+    this.props.exampleLink = props.exampleLink || ''
     // old wordy used to not have createdAt. So, if createdAt not present, it will set it based on dateAdded.
     if (!this.props.createdAt) this.props.createdAt = new Date(props.dateAdded)
   }
@@ -52,6 +52,7 @@ export class WordDomain extends DomainRoot {
       pronunciation: dto.pronunciation,
       definition: dto.definition,
       example: dto.example,
+      exampleLink: dto.exampleLink,
       tags: dto.tags,
       dateAdded: new Date().valueOf(),
     })
@@ -70,6 +71,7 @@ export class WordDomain extends DomainRoot {
       pronunciation: props.pronun,
       definition: props.meaning,
       example: props.example,
+      exampleLink: props.exampleLink,
       tags: props.tag,
       dateAdded: props.dateAdded,
       createdAt: props.createdAt
@@ -113,6 +115,7 @@ export class WordDomain extends DomainRoot {
       pronun: this.props.pronunciation,
       meaning: this.props.definition,
       example: this.props.example,
+      exampleLink: this.props.exampleLink,
       tag: this.props.tags,
       ownerID: this.props.userId,
       dateAdded: this.props.dateAdded,
@@ -155,6 +158,7 @@ export class WordDomain extends DomainRoot {
             pronun: dto.pronunciation,
             meaning: dto.definition,
             example: dto.example,
+            exampleLink: dto.exampleLink,
             tag: dto.tags,
           },
           { new: true },

--- a/src/dto/get-word-query.dto.ts
+++ b/src/dto/get-word-query.dto.ts
@@ -59,6 +59,10 @@ export class GetWordQueryDTO
   @IsString()
   example: string
 
+  @IsOptional()
+  @IsString()
+  exampleLink: string
+
   @Transform(intoNumber)
   @IsOptional()
   @IsNumber()

--- a/src/dto/post-word-body.dto.ts
+++ b/src/dto/post-word-body.dto.ts
@@ -27,6 +27,9 @@ export class PostWordBodyDTO {
   @IsString()
   example: string
 
+  @IsString()
+  exampleLink: string
+
   @Transform(intoArray)
   @IsArray()
   tags: string[]

--- a/src/dto/put-word-body.dto.ts
+++ b/src/dto/put-word-body.dto.ts
@@ -32,6 +32,10 @@ export class PutWordByIdBodyDTO {
   @IsOptional()
   example: string
 
+  @IsString()
+  @IsOptional()
+  exampleLink: string
+
   @Transform(intoArray)
   @IsArray()
   @IsOptional()

--- a/src/schemas/deprecated-word.schema.ts
+++ b/src/schemas/deprecated-word.schema.ts
@@ -28,6 +28,9 @@ export class WordProps {
   example: string // example sentence
 
   @Prop()
+  exampleLink: string // example sentence link
+
+  @Prop()
   sem: number //231
 
   @Prop()


### PR DESCRIPTION
# Background
When you study word, you want to know where you get the words. Wordnote now supports link for example sentence to make yourself remember your words even more.

## TODOs
- [x] Post with ExampleLink
- [x] Get Word that does not have ExampleLink
- [x] Get Word with ExampleLink
- [x] Put Word with ExampleLink

## Related PRs
- https://github.com/ajktown/docs/pull/21
- https://github.com/ajktown/api/pull/56
- https://github.com/ajktown/wordnote/pull/87

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PR is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked