### PR TITLE
Example undefined bug fix

### DIFF
--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -29,6 +29,7 @@ export class WordDomain extends DomainRoot {
     this.props = props
 
     this.props.tags = this.intoTrimmedAndUniqueArray(props.tags) // every tag must be trimmed/unique all the time
+    this.props.example = props.example || ''
     this.props.exampleLink = props.exampleLink || ''
     // old wordy used to not have createdAt. So, if createdAt not present, it will set it based on dateAdded.
     if (!this.props.createdAt) this.props.createdAt = new Date(props.dateAdded)


### PR DESCRIPTION

# Background
There is a bug that sometimes non-string is returned for `example` of `WordDomain`

## TODOs
- [x] Fix the bug

## Related PRs
- _None_

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PRs is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
