### PR TITLE
UserEntity without createdAt bug with UserDomain

### DIFF
--- a/src/domains/auth/access-token.domain.ts
+++ b/src/domains/auth/access-token.domain.ts
@@ -41,6 +41,11 @@ export class AccessTokenDomain {
     return this.props.profileImageUrl
   }
 
+  get isFirstTimeUser(): boolean {
+    if (!this.props.createdAt) return false // it is considered not a first time user, if createdAt is not present
+    return new Date().valueOf() < new Date(this.props.createdAt).valueOf() + 20
+  }
+
   static fromUser(user: UserDomain, req?: Request) {
     const userRes = user.toResDTO()
     return new AccessTokenDomain(
@@ -48,7 +53,7 @@ export class AccessTokenDomain {
         userEmail: userRes.email,
         userId: userRes.id,
         profileImageUrl: userRes.imageUrl,
-        createdAt: userRes.createdAt.toISOString(),
+        createdAt: userRes.createdAt?.toISOString(),
       },
       getTimezone(req),
     )
@@ -83,8 +88,7 @@ export class AccessTokenDomain {
       profileImageUrl: this.props.profileImageUrl,
       timezone: this.timezone,
       // The user is considered the first time user, if the user has signed up within 10 seconds.
-      isFirstTimeUser:
-        new Date().valueOf() < new Date(this.props.createdAt).valueOf() + 20,
+      isFirstTimeUser: this.isFirstTimeUser,
     }
   }
 


### PR DESCRIPTION
# Background
Bug was introduced in the PR https://github.com/ajktown/api/pull/71 where old users without `createdAt` for UserEntityDoc  was not able to sign in.

## TODOs
- [X] Fix the sign in problem

## Checklist (Developers)
- [ ] Make this PR as a draft first
- [ ] Title is checked
- [ ] Background & TODOs are filled
- [ ] Assignee is set
- [ ] Labels are set
- [ ] Project is created & linked, if multiple PRs are associated to this PR
- [ ] Appropriate issue(s) is(are) linked to this PR under `development`
- [ ] `yarn inspect` is run
- [ ] `TODOs` are handled and checked
- [ ] Final Operation Check is done
- [ ] Make this PR as an open PR

## Checklist (Reviewers)
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
