### PR TITLE
Action group returns in time order

### DIFF
--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -16,15 +16,8 @@ export class RitualGroupDomain extends DomainRoot {
     atd: AccessTokenDomain,
     actionGroupModel: ActionGroupModel,
   ): Promise<RitualGroupDomain> {
-    const docs = await actionGroupModel.find({
-      ownerId: atd.userId,
-    })
-
     return new RitualGroupDomain([
-      RitualDomain.fromUnassociatedActionGroupIds(
-        atd,
-        docs.map((doc) => doc.id),
-      ),
+      await RitualDomain.fromUnassociatedActionGroupIds(atd, actionGroupModel),
     ])
   }
 

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -2,6 +2,7 @@ import { DomainRoot } from '../index.root'
 import { AccessTokenDomain } from '../auth/access-token.domain'
 import { IRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
+import { ActionGroupModel } from '@/schemas/action-group.schema'
 
 /**
  * Ritual domain groups the ActionDomain
@@ -19,15 +20,19 @@ export class RitualDomain extends DomainRoot {
     this.props = input
   }
 
-  static fromUnassociatedActionGroupIds(
+  static async fromUnassociatedActionGroupIds(
     atd: AccessTokenDomain,
-    ids: string[],
-  ): RitualDomain {
+    actionGroupModel: ActionGroupModel,
+  ): Promise<RitualDomain> {
+    const docs = await actionGroupModel.find({
+      ownerId: atd.userId,
+    })
+
     return new RitualDomain({
       id: 'default',
       ownerId: atd.userId,
       name: 'Unassociated Ritual',
-      actionGroupIds: ids,
+      actionGroupIds: docs.map((doc) => doc.id),
     })
   }
 

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -32,7 +32,10 @@ export class RitualDomain extends DomainRoot {
       id: 'default',
       ownerId: atd.userId,
       name: 'Unassociated Ritual',
-      actionGroupIds: docs.map((doc) => doc.id),
+      actionGroupIds: docs
+        .sort((a, b) => a.openMinsAfter - b.openMinsAfter)
+        .sort((a, b) => a.closeMinsAfter - b.closeMinsAfter)
+        .map((doc) => doc.id),
     })
   }
 


### PR DESCRIPTION
# Background
The api returns action groups in the order of how its stored.
The order should be sorted in the way, that the oldest ending time always go to the last and
the earlier ones stay in the front.

## TODOs
- [x] Fix the order

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
