### PR TITLE
GET /rituals returns real ritual

### DIFF
--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -22,6 +22,6 @@ export class RitualController {
   @Get(RitualControllerPath.GetRituals)
   async getRituals(@Req() req: Request) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    return (await this.ritualService.byAtd(atd)).toDeprecatedResDTO(atd)
+    return (await this.ritualService.byAtd(atd)).toResDTO(atd)
   }
 }

--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -22,6 +22,6 @@ export class RitualController {
   @Get(RitualControllerPath.GetRituals)
   async getRituals(@Req() req: Request) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    return (await this.ritualService.get(atd)).toDeprecatedResDTO(atd)
+    return (await this.ritualService.byAtd(atd)).toDeprecatedResDTO(atd)
   }
 }

--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -22,6 +22,6 @@ export class RitualController {
   @Get(RitualControllerPath.GetRituals)
   async getRituals(@Req() req: Request) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    return (await this.ritualService.get(atd)).toResDTO(atd)
+    return (await this.ritualService.get(atd)).toDeprecatedResDTO(atd)
   }
 }

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -175,6 +175,7 @@ export class ActionGroupDomain extends DomainRoot {
   }
 
   async postAction(
+    // TODO: atd is not yet used
     atd: AccessTokenDomain,
     actionModel: ActionModel,
   ): Promise<this> {

--- a/src/domains/ritual/index.interface.ts
+++ b/src/domains/ritual/index.interface.ts
@@ -1,3 +1,13 @@
+// TODO: There should be ISharedRitual
+// export interface ISharedRitual {
+//   name: string
+//   actionGroupIds: string[]
+// }
+// export interface IRitual extends ISharedRitual {
+//   id: string
+//   ownerId: string
+// }
+
 export interface IRitual {
   id: string
   ownerId: string

--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -73,7 +73,7 @@ export class RitualGroupDomain extends DomainRoot {
     )
   }
 
-  toDeprecatedResDTO(atd: AccessTokenDomain): GetRitualsRes {
+  toResDTO(atd: AccessTokenDomain): GetRitualsRes {
     return {
       rituals: this.domains.map((domain) => domain.toResDTO(atd)),
     }

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -2,8 +2,7 @@ import { DomainRoot } from '../index.root'
 import { AccessTokenDomain } from '../auth/access-token.domain'
 import { IRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
-import { ActionGroupDoc, ActionGroupModel } from '@/schemas/action-group.schema'
-import { UserDomain } from '../user/user.domain'
+import { ActionGroupDoc } from '@/schemas/action-group.schema'
 import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
 
 /**
@@ -54,63 +53,6 @@ export class RitualDomain extends DomainRoot {
       ownerId: doc.ownerId,
       name: doc.name,
       actionGroupIds: actionGroupDocs.map((doc) => doc.id),
-    })
-  }
-
-  static async deprecatedFromMdb(
-    atd: AccessTokenDomain,
-    actionGroupModel: ActionGroupModel,
-  ): Promise<RitualDomain> {
-    const docs = await actionGroupModel.find({
-      ownerId: atd.userId,
-    })
-
-    return new RitualDomain({
-      id: 'default',
-      ownerId: atd.userId,
-      name: 'Unassociated Ritual',
-      actionGroupIds: docs
-        .sort((a, b) => a.openMinsAfter - b.openMinsAfter)
-        .sort((a, b) => a.closeMinsAfter - b.closeMinsAfter)
-        .map((doc) => doc.id),
-    })
-  }
-
-  static async fromUnassociatedActionGroupIds(
-    atd: AccessTokenDomain,
-    actionGroupModel: ActionGroupModel,
-  ): Promise<RitualDomain> {
-    const docs = await actionGroupModel.find({
-      ownerId: atd.userId,
-    })
-
-    return new RitualDomain({
-      id: 'default',
-      ownerId: atd.userId,
-      name: 'Unassociated Ritual',
-      actionGroupIds: docs
-        .sort((a, b) => a.openMinsAfter - b.openMinsAfter)
-        .sort((a, b) => a.closeMinsAfter - b.closeMinsAfter)
-        .map((doc) => doc.id),
-    })
-  }
-
-  static async fromUser(
-    user: UserDomain,
-    actionGroupModel: ActionGroupModel,
-  ): Promise<RitualDomain> {
-    const docs = await actionGroupModel.find({
-      ownerId: user.id,
-    })
-
-    return new RitualDomain({
-      id: 'default',
-      ownerId: user.id,
-      name: 'Unassociated Ritual',
-      actionGroupIds: docs
-        .sort((a, b) => a.openMinsAfter - b.openMinsAfter)
-        .sort((a, b) => a.closeMinsAfter - b.closeMinsAfter)
-        .map((doc) => doc.id),
     })
   }
 

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -2,8 +2,9 @@ import { DomainRoot } from '../index.root'
 import { AccessTokenDomain } from '../auth/access-token.domain'
 import { IRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
-import { ActionGroupModel } from '@/schemas/action-group.schema'
+import { ActionGroupDoc, ActionGroupModel } from '@/schemas/action-group.schema'
 import { UserDomain } from '../user/user.domain'
+import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
 
 /**
  * Ritual domain groups the ActionDomain
@@ -19,6 +20,60 @@ export class RitualDomain extends DomainRoot {
   private constructor(input: IRitual) {
     super()
     this.props = input
+  }
+
+  /**
+   * Post a default ritual for the user.
+   * This is called when the user has no ritual, but
+   * it guarantees that the API works fine, even if it is called more than once.
+   */
+  static async postDefault(
+    atd: AccessTokenDomain,
+    model: RitualModel,
+  ): Promise<RitualDomain> {
+    const newRitualDoc = await new model({
+      ownerId: atd.userId,
+      name: 'Default Ritual',
+      actionGroupIds: [],
+    }).save()
+
+    return new RitualDomain({
+      id: newRitualDoc.id,
+      ownerId: newRitualDoc.ownerId,
+      name: newRitualDoc.name,
+      actionGroupIds: newRitualDoc.actionGroupIds,
+    })
+  }
+
+  static fromDoc(
+    doc: RitualDoc,
+    actionGroupDocs: ActionGroupDoc[],
+  ): RitualDomain {
+    return new RitualDomain({
+      id: doc.id,
+      ownerId: doc.ownerId,
+      name: doc.name,
+      actionGroupIds: actionGroupDocs.map((doc) => doc.id),
+    })
+  }
+
+  static async deprecatedFromMdb(
+    atd: AccessTokenDomain,
+    actionGroupModel: ActionGroupModel,
+  ): Promise<RitualDomain> {
+    const docs = await actionGroupModel.find({
+      ownerId: atd.userId,
+    })
+
+    return new RitualDomain({
+      id: 'default',
+      ownerId: atd.userId,
+      name: 'Unassociated Ritual',
+      actionGroupIds: docs
+        .sort((a, b) => a.openMinsAfter - b.openMinsAfter)
+        .sort((a, b) => a.closeMinsAfter - b.closeMinsAfter)
+        .map((doc) => doc.id),
+    })
   }
 
   static async fromUnassociatedActionGroupIds(

--- a/src/modules/ritual.module.ts
+++ b/src/modules/ritual.module.ts
@@ -3,9 +3,15 @@ import { RitualService } from '@/services/ritual.service'
 import { actionGroupModelDefinition } from '@/schemas/action-group.schema'
 import { MongooseModule } from '@nestjs/mongoose'
 import { RitualController } from '@/controllers/ritual.controller'
+import { ritualModelDefinition } from '@/schemas/ritual.schema'
 
 @Module({
-  imports: [MongooseModule.forFeature([actionGroupModelDefinition])],
+  imports: [
+    MongooseModule.forFeature([
+      ritualModelDefinition,
+      actionGroupModelDefinition,
+    ]),
+  ],
   controllers: [RitualController],
   providers: [Logger, RitualService],
 })

--- a/src/modules/user.module.ts
+++ b/src/modules/user.module.ts
@@ -12,6 +12,7 @@ import { WordService } from '@/services/word.service'
 import { TermToExamplePrompt } from '@/prompts/term-to-example.prompt'
 import { GetWordQueryFactory } from '@/factories/get-word-query.factory'
 import { ActionGroupService } from '@/services/action-group.service'
+import { ritualModelDefinition } from '@/schemas/ritual.schema'
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ActionGroupService } from '@/services/action-group.service'
       wordModelDefinition,
       supportsModelDefinition,
       actionModelDefinition,
+      ritualModelDefinition,
     ]),
   ],
   controllers: [UserController],

--- a/src/schemas/index.collections.ts
+++ b/src/schemas/index.collections.ts
@@ -8,6 +8,7 @@ export enum SchemaCollectionName {
   SharedResources = `shared-resources`,
   Actions = 'actions',
   ActionGroups = 'action-groups',
+  Rituals = `rituals`,
 }
 
 export enum DiscriminatorKey {

--- a/src/schemas/ritual.schema.ts
+++ b/src/schemas/ritual.schema.ts
@@ -1,0 +1,35 @@
+import { DataBasicsDate } from '@/global.interface'
+import { ModelDefinition, Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import { HydratedDocument, Model } from 'mongoose'
+import {
+  defaultSchemaTimestampsConfig,
+  SchemaCollectionName,
+} from './index.collections'
+
+/**
+ */
+export type RitualDoc = HydratedDocument<RitualProps, DataBasicsDate>
+
+export type RitualModel = Model<RitualDoc>
+
+@Schema({
+  collection: SchemaCollectionName.Rituals,
+  timestamps: defaultSchemaTimestampsConfig,
+})
+export class RitualProps {
+  @Prop({ required: true })
+  ownerId: string // the owner id 5f85729......
+
+  @Prop({ required: true })
+  name: string // not required to be unique
+
+  @Prop({ required: true })
+  actionGroupIds: string[]
+}
+
+export const RitualSchema = SchemaFactory.createForClass(RitualProps)
+
+export const ritualModelDefinition: ModelDefinition = {
+  name: RitualProps.name,
+  schema: RitualSchema,
+}

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -19,9 +19,9 @@ export class RitualService {
   ) {}
 
   /**
-   * get returns RitualDomain of a user by access token domain (or requester)
+   * byAtd returns RitualDomain of a user by access token domain (or requester)
    */
-  async get(atd: AccessTokenDomain): Promise<RitualGroupDomain> {
+  async byAtd(atd: AccessTokenDomain): Promise<RitualGroupDomain> {
     return RitualGroupDomain.fromMdb(
       atd,
       this.ritualModel,

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -15,10 +15,16 @@ export class RitualService {
     private actionGroupModel: ActionGroupModel,
   ) {}
 
+  /**
+   * get returns RitualDomain of a user by access token domain (or requester)
+   */
   async get(atd: AccessTokenDomain): Promise<RitualGroupDomain> {
     return RitualGroupDomain.fromMdb(atd, this.actionGroupModel)
   }
 
+  /**
+   * byUser returns RitualDomain of a user by user domain.
+   */
   async byUser(userDomain: UserDomain): Promise<RitualGroupDomain> {
     return RitualGroupDomain.fromUser(userDomain, this.actionGroupModel)
   }

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -7,10 +7,13 @@ import {
 import { InjectModel } from '@nestjs/mongoose'
 import { RitualGroupDomain } from '@/domains/ritual/ritual-group.domain'
 import { UserDomain } from '@/domains/user/user.domain'
+import { RitualModel, RitualProps } from '@/schemas/ritual.schema'
 
 @Injectable()
 export class RitualService {
   constructor(
+    @InjectModel(RitualProps.name)
+    private ritualModel: RitualModel,
     @InjectModel(ActionGroupProps.name)
     private actionGroupModel: ActionGroupModel,
   ) {}
@@ -19,7 +22,11 @@ export class RitualService {
    * get returns RitualDomain of a user by access token domain (or requester)
    */
   async get(atd: AccessTokenDomain): Promise<RitualGroupDomain> {
-    return RitualGroupDomain.fromMdb(atd, this.actionGroupModel)
+    return RitualGroupDomain.fromMdb(
+      atd,
+      this.ritualModel,
+      this.actionGroupModel,
+    )
   }
 
   /**

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -33,6 +33,10 @@ export class RitualService {
    * byUser returns RitualDomain of a user by user domain.
    */
   async byUser(userDomain: UserDomain): Promise<RitualGroupDomain> {
-    return RitualGroupDomain.fromUser(userDomain, this.actionGroupModel)
+    return RitualGroupDomain.fromUser(
+      userDomain,
+      this.ritualModel,
+      this.actionGroupModel,
+    )
   }
 }


### PR DESCRIPTION
# Background
CGT does not yet offer changing order of the action groups.
Ritual Domain will have its child action groups' order.
This PR first creates RitualSchema and related changes to do the following:
- Default Ritual created if not exist yet
- Ritual Schema introduced and actually saved in DB

## TODOs
- [x] Ritual Schema and related ones
- [x] Create default ritual if not have 
- [x] Maintain original features without FE required to be changed

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x ] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x  Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
