### PR TITLE
PUT ritual/default

### DIFF
--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -1,15 +1,18 @@
-import { Controller, Get, Req } from '@nestjs/common'
+import { Body, Controller, Get, Patch, Req } from '@nestjs/common'
 import { AjkTownApiVersion } from './index.interface'
 import { Request } from 'express'
 import { JwtService } from '@nestjs/jwt'
 import { AccessTokenDomain } from '@/domains/auth/access-token.domain'
 import { RitualService } from '@/services/ritual.service'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 
 /**
  * Warning: Since Action Group is a huge domain, it only returns the ids of the action groups.
  */
 export enum RitualControllerPath {
   GetRituals = `rituals`,
+  PatchDefaultRitual = `rituals/default`,
+  // TODO: Eventually the patch should be applied by ID, but since only one ritual exists on Mar 20, 2024, it is not implemented
 }
 
 @Controller(AjkTownApiVersion.V1)
@@ -23,5 +26,14 @@ export class RitualController {
   async getRituals(@Req() req: Request) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
     return (await this.ritualService.byAtd(atd)).toResDTO(atd)
+  }
+
+  @Patch(RitualControllerPath.PatchDefaultRitual)
+  async patchDefaultRitual(
+    @Req() req: Request,
+    @Body() dto: PatchRitualGroupBodyDTO,
+  ) {
+    const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
+    await this.ritualService.patchDefault(atd, dto)
   }
 }

--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -34,6 +34,6 @@ export class RitualController {
     @Body() dto: PatchRitualGroupBodyDTO,
   ) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    await this.ritualService.patchDefault(atd, dto)
+    return (await this.ritualService.patchDefault(atd, dto)).toResDTO()
   }
 }

--- a/src/domains/ritual/index.interface.ts
+++ b/src/domains/ritual/index.interface.ts
@@ -12,7 +12,7 @@ export interface IRitual {
   id: string
   ownerId: string
   name: string
-  actionGroupIds: string[]
+  orderedActionGroupIds: string[]
 }
 
 // export interface IRitualDerived {

--- a/src/domains/ritual/index.interface.ts
+++ b/src/domains/ritual/index.interface.ts
@@ -14,3 +14,7 @@ export interface IRitual {
   name: string
   actionGroupIds: string[]
 }
+
+// export interface IRitualDerived {
+//   actionGroupIds: string[]
+// }

--- a/src/domains/ritual/index.interface.ts
+++ b/src/domains/ritual/index.interface.ts
@@ -15,6 +15,6 @@ export interface IRitual {
   orderedActionGroupIds: string[]
 }
 
-// export interface IRitualDerived {
-//   actionGroupIds: string[]
-// }
+export interface IParentRitual extends IRitual {
+  actionGroupIds: string[]
+}

--- a/src/domains/ritual/parent-ritual.domain.ts
+++ b/src/domains/ritual/parent-ritual.domain.ts
@@ -1,0 +1,87 @@
+import { DomainRoot } from '../index.root'
+import { AccessTokenDomain } from '../auth/access-token.domain'
+import { IParentRitual } from './index.interface'
+import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
+import { ActionGroupDoc } from '@/schemas/action-group.schema'
+import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+
+/**
+ * ParentRitualDomain has both values:
+ *   - RitualDomain
+ *   - ActionGroup ids
+ * i.e) ritual domain: early bird
+ * i.e) .. Wake up by 4:30am
+ * i.e) .. Take supplement by 4:30am
+ * TODO: Maybe enforcing the same end time is a good strategy, for users
+ * TODO: to maintain, OR we can suggest them to do so
+ */
+export class ParentRitualDomain extends DomainRoot {
+  private readonly props: IParentRitual
+
+  private constructor(input: IParentRitual) {
+    super()
+    this.props = input
+  }
+
+  get id() {
+    return this.props.id
+  }
+
+  /**
+   * Ritual takes responsibility of the order of action groups
+   */
+  static fromDoc(
+    doc: RitualDoc,
+    actionGroupDocs: ActionGroupDoc[],
+  ): ParentRitualDomain {
+    // map contains user's own order of action groups
+    // the lower the i (or index), the higher the priority it should be seen
+    // despite of its openMinsAfter or closeMinsAfter
+    const map = new Map(doc.orderedActionGroupIds.map((id, i) => [id, i]))
+
+    return new ParentRitualDomain({
+      id: doc.id,
+      ownerId: doc.ownerId,
+      name: doc.name,
+      orderedActionGroupIds: doc.orderedActionGroupIds,
+      actionGroupIds: actionGroupDocs
+        .sort((a, b) => {
+          if (map.has(a.id) && map.has(b.id)) {
+            return map.get(a.id) - map.get(b.id)
+          }
+          if (a.closeMinsAfter !== b.closeMinsAfter)
+            return a.closeMinsAfter - b.closeMinsAfter
+          return a.openMinsAfter - b.openMinsAfter
+        })
+        .map((doc) => doc.id),
+    })
+  }
+
+  toResDTO(): IParentRitual {
+    return this.props
+  }
+
+  toDerivedResDTO(atd: AccessTokenDomain): IParentRitual {
+    if (atd.userId !== this.props.ownerId) {
+      throw new ReadForbiddenError(atd, `Ritual`)
+    }
+    return this.props
+  }
+
+  // TODO: This should return IRitualShared
+  toSharedResDTO(): IParentRitual {
+    return this.props
+  }
+
+  async patch(dto: PatchRitualGroupBodyDTO, model: RitualModel): Promise<void> {
+    await model.findByIdAndUpdate(
+      this.id,
+      {
+        // name: dto.name, // TODO: Name is not yet supported
+        orderedActionGroupIds: dto.orderedActionGroupIds,
+      },
+      { new: true },
+    )
+  }
+}

--- a/src/domains/ritual/parent-ritual.domain.ts
+++ b/src/domains/ritual/parent-ritual.domain.ts
@@ -64,7 +64,7 @@ export class ParentRitualDomain extends DomainRoot {
 
   toDerivedResDTO(atd: AccessTokenDomain): IParentRitual {
     if (atd.userId !== this.props.ownerId) {
-      throw new ReadForbiddenError(atd, `Ritual`)
+      throw new ReadForbiddenError(atd, `ParentRitual`)
     }
     return this.props
   }

--- a/src/domains/ritual/parent-ritual.domain.ts
+++ b/src/domains/ritual/parent-ritual.domain.ts
@@ -3,8 +3,7 @@ import { AccessTokenDomain } from '../auth/access-token.domain'
 import { IParentRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
 import { ActionGroupDoc } from '@/schemas/action-group.schema'
-import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
-import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+import { RitualDoc } from '@/schemas/ritual.schema'
 
 /**
  * ParentRitualDomain has both values:
@@ -29,7 +28,7 @@ export class ParentRitualDomain extends DomainRoot {
   }
 
   /**
-   * Ritual takes responsibility of the order of action groups
+   * ParentRitual takes responsibility of the order of action groups
    */
   static fromDoc(
     doc: RitualDoc,
@@ -72,16 +71,5 @@ export class ParentRitualDomain extends DomainRoot {
   // TODO: This should return IRitualShared
   toSharedResDTO(): IParentRitual {
     return this.props
-  }
-
-  async patch(dto: PatchRitualGroupBodyDTO, model: RitualModel): Promise<void> {
-    await model.findByIdAndUpdate(
-      this.id,
-      {
-        // name: dto.name, // TODO: Name is not yet supported
-        orderedActionGroupIds: dto.orderedActionGroupIds,
-      },
-      { new: true },
-    )
   }
 }

--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -7,6 +7,7 @@ import { UserDomain } from '../user/user.domain'
 import { RitualModel } from '@/schemas/ritual.schema'
 import { BadRequestError } from '@/errors/400/index.error'
 import { NotExistOrNoPermissionError } from '@/errors/404/not-exist-or-no-permission.error'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 
 export class RitualGroupDomain extends DomainRoot {
   private readonly domains: RitualDomain[]
@@ -14,6 +15,12 @@ export class RitualGroupDomain extends DomainRoot {
   private constructor(domains: RitualDomain[]) {
     super()
     this.domains = domains
+  }
+
+  // default is the first one always.
+  private getDefault(): RitualDomain {
+    if (this.domains.length === 0) throw new NotExistOrNoPermissionError()
+    return this.domains[0]
   }
 
   /**
@@ -75,7 +82,7 @@ export class RitualGroupDomain extends DomainRoot {
 
   toResDTO(atd: AccessTokenDomain): GetRitualsRes {
     return {
-      rituals: this.domains.map((domain) => domain.toResDTO(atd)),
+      rituals: this.domains.map((domain) => domain.toDerivedResDTO(atd)),
     }
   }
 
@@ -84,5 +91,12 @@ export class RitualGroupDomain extends DomainRoot {
     return {
       rituals: this.domains.map((domain) => domain.toSharedResDTO()),
     }
+  }
+
+  async patchDefault(
+    dto: PatchRitualGroupBodyDTO,
+    model: RitualModel,
+  ): Promise<void> {
+    await this.getDefault().patch(dto, model)
   }
 }

--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -8,17 +8,18 @@ import { RitualModel } from '@/schemas/ritual.schema'
 import { BadRequestError } from '@/errors/400/index.error'
 import { NotExistOrNoPermissionError } from '@/errors/404/not-exist-or-no-permission.error'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+import { ParentRitualDomain } from './parent-ritual.domain'
 
 export class RitualGroupDomain extends DomainRoot {
-  private readonly domains: RitualDomain[]
+  private readonly domains: ParentRitualDomain[]
 
-  private constructor(domains: RitualDomain[]) {
+  private constructor(domains: ParentRitualDomain[]) {
     super()
     this.domains = domains
   }
 
   // default is the first one always.
-  private getDefault(): RitualDomain {
+  private getDefault(): ParentRitualDomain {
     if (this.domains.length === 0) throw new NotExistOrNoPermissionError()
     return this.domains[0]
   }
@@ -50,7 +51,7 @@ export class RitualGroupDomain extends DomainRoot {
       ownerId: atd.userId,
     })
     return new RitualGroupDomain(
-      ritualDocs.map((doc) => RitualDomain.fromDoc(doc, actionGroupDocs)),
+      ritualDocs.map((doc) => ParentRitualDomain.fromDoc(doc, actionGroupDocs)),
     )
   }
 
@@ -76,7 +77,7 @@ export class RitualGroupDomain extends DomainRoot {
       ownerId: userDomain.id,
     })
     return new RitualGroupDomain(
-      ritualDocs.map((doc) => RitualDomain.fromDoc(doc, actionGroupDocs)),
+      ritualDocs.map((doc) => ParentRitualDomain.fromDoc(doc, actionGroupDocs)),
     )
   }
 

--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -7,7 +7,6 @@ import { UserDomain } from '../user/user.domain'
 import { RitualModel } from '@/schemas/ritual.schema'
 import { BadRequestError } from '@/errors/400/index.error'
 import { NotExistOrNoPermissionError } from '@/errors/404/not-exist-or-no-permission.error'
-import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 import { ParentRitualDomain } from './parent-ritual.domain'
 
 export class RitualGroupDomain extends DomainRoot {
@@ -19,9 +18,9 @@ export class RitualGroupDomain extends DomainRoot {
   }
 
   // default is the first one always.
-  private getDefault(): ParentRitualDomain {
+  getDefault(): RitualDomain {
     if (this.domains.length === 0) throw new NotExistOrNoPermissionError()
-    return this.domains[0]
+    return RitualDomain.fromParentRitual(this.domains[0].toResDTO())
   }
 
   /**
@@ -92,12 +91,5 @@ export class RitualGroupDomain extends DomainRoot {
     return {
       rituals: this.domains.map((domain) => domain.toSharedResDTO()),
     }
-  }
-
-  async patchDefault(
-    dto: PatchRitualGroupBodyDTO,
-    model: RitualModel,
-  ): Promise<void> {
-    await this.getDefault().patch(dto, model)
   }
 }

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -4,6 +4,7 @@ import { IRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
 import { ActionGroupDoc } from '@/schemas/action-group.schema'
 import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 
 /**
  * Ritual domain groups the ActionDomain
@@ -19,6 +20,10 @@ export class RitualDomain extends DomainRoot {
   private constructor(input: IRitual) {
     super()
     this.props = input
+  }
+
+  get id() {
+    return this.props.id
   }
 
   /**
@@ -73,7 +78,11 @@ export class RitualDomain extends DomainRoot {
     })
   }
 
-  toResDTO(atd: AccessTokenDomain): IRitual {
+  toResDTO(): IRitual {
+    return this.props
+  }
+
+  toDerivedResDTO(atd: AccessTokenDomain): IRitual {
     if (atd.userId !== this.props.ownerId) {
       throw new ReadForbiddenError(atd, `Ritual`)
     }
@@ -83,5 +92,16 @@ export class RitualDomain extends DomainRoot {
   // TODO: This should return IRitualShared
   toSharedResDTO(): IRitual {
     return this.props
+  }
+
+  async patch(dto: PatchRitualGroupBodyDTO, model: RitualModel): Promise<void> {
+    await model.findByIdAndUpdate(
+      this.id,
+      {
+        // name: dto.name, // TODO: Name is not yet supported
+        actionGroupIds: dto.actionGroupIds,
+      },
+      { new: true },
+    )
   }
 }

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -2,8 +2,7 @@ import { DomainRoot } from '../index.root'
 import { AccessTokenDomain } from '../auth/access-token.domain'
 import { IRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
-import { ActionGroupDoc } from '@/schemas/action-group.schema'
-import { RitualDoc, RitualModel } from '@/schemas/ritual.schema'
+import { RitualModel } from '@/schemas/ritual.schema'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 
 /**
@@ -46,35 +45,6 @@ export class RitualDomain extends DomainRoot {
       ownerId: newRitualDoc.ownerId,
       name: newRitualDoc.name,
       orderedActionGroupIds: newRitualDoc.orderedActionGroupIds,
-    })
-  }
-
-  /**
-   * Ritual takes responsibility of the order of action groups
-   */
-  static fromDoc(
-    doc: RitualDoc,
-    actionGroupDocs: ActionGroupDoc[],
-  ): RitualDomain {
-    // map contains user's own order of action groups
-    // the lower the i (or index), the higher the priority it should be seen
-    // despite of its openMinsAfter or closeMinsAfter
-    const map = new Map(doc.orderedActionGroupIds.map((id, i) => [id, i]))
-
-    return new RitualDomain({
-      id: doc.id,
-      ownerId: doc.ownerId,
-      name: doc.name,
-      orderedActionGroupIds: actionGroupDocs
-        .sort((a, b) => {
-          if (map.has(a.id) && map.has(b.id)) {
-            return map.get(a.id) - map.get(b.id)
-          }
-          if (a.closeMinsAfter !== b.closeMinsAfter)
-            return a.closeMinsAfter - b.closeMinsAfter
-          return a.openMinsAfter - b.openMinsAfter
-        })
-        .map((doc) => doc.id),
     })
   }
 

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -38,14 +38,14 @@ export class RitualDomain extends DomainRoot {
     const newRitualDoc = await new model({
       ownerId: atd.userId,
       name: 'Default Ritual',
-      actionGroupIds: [],
+      orderedActionGroupIds: [],
     }).save()
 
     return new RitualDomain({
       id: newRitualDoc.id,
       ownerId: newRitualDoc.ownerId,
       name: newRitualDoc.name,
-      actionGroupIds: newRitualDoc.actionGroupIds,
+      orderedActionGroupIds: newRitualDoc.orderedActionGroupIds,
     })
   }
 
@@ -59,13 +59,13 @@ export class RitualDomain extends DomainRoot {
     // map contains user's own order of action groups
     // the lower the i (or index), the higher the priority it should be seen
     // despite of its openMinsAfter or closeMinsAfter
-    const map = new Map(doc.actionGroupIds.map((id, i) => [id, i]))
+    const map = new Map(doc.orderedActionGroupIds.map((id, i) => [id, i]))
 
     return new RitualDomain({
       id: doc.id,
       ownerId: doc.ownerId,
       name: doc.name,
-      actionGroupIds: actionGroupDocs
+      orderedActionGroupIds: actionGroupDocs
         .sort((a, b) => {
           if (map.has(a.id) && map.has(b.id)) {
             return map.get(a.id) - map.get(b.id)
@@ -99,7 +99,7 @@ export class RitualDomain extends DomainRoot {
       this.id,
       {
         // name: dto.name, // TODO: Name is not yet supported
-        actionGroupIds: dto.actionGroupIds,
+        orderedActionGroupIds: dto.orderedActionGroupIds,
       },
       { new: true },
     )

--- a/src/dto/patch-ritual-group-body.dto.ts
+++ b/src/dto/patch-ritual-group-body.dto.ts
@@ -1,0 +1,11 @@
+import { Transform } from 'class-transformer'
+import { IsArray, IsOptional } from 'class-validator'
+import { intoArray } from './index.validator'
+
+// TODO: Name should be modifiable, but not yet supported.
+export class PatchRitualGroupBodyDTO {
+  @Transform(intoArray)
+  @IsOptional()
+  @IsArray()
+  actionGroupIds: string[]
+}

--- a/src/dto/patch-ritual-group-body.dto.ts
+++ b/src/dto/patch-ritual-group-body.dto.ts
@@ -7,5 +7,5 @@ export class PatchRitualGroupBodyDTO {
   @Transform(intoArray)
   @IsOptional()
   @IsArray()
-  actionGroupIds: string[]
+  orderedActionGroupIds: string[]
 }

--- a/src/dto/patch-ritual-group-body.dto.ts
+++ b/src/dto/patch-ritual-group-body.dto.ts
@@ -7,5 +7,5 @@ export class PatchRitualGroupBodyDTO {
   @Transform(intoArray)
   @IsOptional()
   @IsArray()
-  orderedActionGroupIds: string[]
+  actionGroupIds: string[]
 }

--- a/src/responses/get-ritual.res.ts
+++ b/src/responses/get-ritual.res.ts
@@ -1,7 +1,7 @@
-import { IRitual } from '@/domains/ritual/index.interface'
+import { IParentRitual, IRitual } from '@/domains/ritual/index.interface'
 
 export interface GetRitualsRes {
-  rituals: IRitual[]
+  rituals: IParentRitual[]
 }
 
 export interface GetRitualByIdRes {

--- a/src/responses/get-ritual.res.ts
+++ b/src/responses/get-ritual.res.ts
@@ -3,3 +3,7 @@ import { IRitual } from '@/domains/ritual/index.interface'
 export interface GetRitualsRes {
   rituals: IRitual[]
 }
+
+export interface GetRitualByIdRes {
+  ritual: IRitual
+}

--- a/src/schemas/ritual.schema.ts
+++ b/src/schemas/ritual.schema.ts
@@ -24,7 +24,7 @@ export class RitualProps {
   name: string // not required to be unique
 
   @Prop({ required: true })
-  actionGroupIds: string[]
+  orderedActionGroupIds: string[]
 }
 
 export const RitualSchema = SchemaFactory.createForClass(RitualProps)

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -8,6 +8,8 @@ import { InjectModel } from '@nestjs/mongoose'
 import { RitualGroupDomain } from '@/domains/ritual/ritual-group.domain'
 import { UserDomain } from '@/domains/user/user.domain'
 import { RitualModel, RitualProps } from '@/schemas/ritual.schema'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+import { RitualDomain } from '@/domains/ritual/ritual.domain'
 
 @Injectable()
 export class RitualService {
@@ -38,5 +40,13 @@ export class RitualService {
       this.ritualModel,
       this.actionGroupModel,
     )
+  }
+
+  async patchDefault(
+    atd: AccessTokenDomain,
+    dto: PatchRitualGroupBodyDTO,
+  ): Promise<void> {
+    const ritualGroup = await this.byAtd(atd)
+    ritualGroup.patchDefault(dto, this.ritualModel)
   }
 }

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -9,7 +9,6 @@ import { RitualGroupDomain } from '@/domains/ritual/ritual-group.domain'
 import { UserDomain } from '@/domains/user/user.domain'
 import { RitualModel, RitualProps } from '@/schemas/ritual.schema'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
-import { RitualDomain } from '@/domains/ritual/ritual.domain'
 
 @Injectable()
 export class RitualService {

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -9,6 +9,7 @@ import { RitualGroupDomain } from '@/domains/ritual/ritual-group.domain'
 import { UserDomain } from '@/domains/user/user.domain'
 import { RitualModel, RitualProps } from '@/schemas/ritual.schema'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+import { RitualDomain } from '@/domains/ritual/ritual.domain'
 
 @Injectable()
 export class RitualService {
@@ -44,8 +45,8 @@ export class RitualService {
   async patchDefault(
     atd: AccessTokenDomain,
     dto: PatchRitualGroupBodyDTO,
-  ): Promise<void> {
+  ): Promise<RitualDomain> {
     const ritualGroup = await this.byAtd(atd)
-    ritualGroup.patchDefault(dto, this.ritualModel)
+    return ritualGroup.getDefault().patch(dto, this.ritualModel)
   }
 }


### PR DESCRIPTION
# Background
We only support at most one ritual per account at this point.
The url only supports default one at this point

## TODOs
- [x] Implement `PATCH /api/v1/rituals/default`

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
