### PR TITLE
Fix security issue `POST /action-groups/:id/action`

### DIFF
--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -175,7 +175,6 @@ export class ActionGroupDomain extends DomainRoot {
   }
 
   async postAction(
-    // TODO: atd is not yet used
     atd: AccessTokenDomain,
     actionModel: ActionModel,
   ): Promise<this> {

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -179,6 +179,9 @@ export class ActionGroupDomain extends DomainRoot {
     atd: AccessTokenDomain,
     actionModel: ActionModel,
   ): Promise<this> {
+    // check if is owned by the user
+    if (this.props.ownerId !== atd.userId) throw new NotExistOrNoPermissionError()
+
     // if today's action exists, throw error
     let docs: ActionDoc[] = []
     try {


### PR DESCRIPTION
# Important notice
The current production API already runs this security fixes 

# Background
Anyone could post action for other users's action as long as they know `action-group`'s `id`

## TODOs
- [x] Fix the bug
- [x] Release to the production

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
