### PR TITLE
Delete today's actions of action group

### DIFF
--- a/src/controllers/action-group.controller.ts
+++ b/src/controllers/action-group.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common'
+import { Body, Controller, Delete, Get, Param, Post, Req } from '@nestjs/common'
 import { AjkTownApiVersion } from './index.interface'
 import { Request } from 'express'
 import { JwtService } from '@nestjs/jwt'
@@ -13,6 +13,7 @@ export enum ActionGroupControllerPath {
   PostActionGroup = `action-groups`,
   PostActionByActionGroup = `action-groups/:id/actions`,
   GetActionGroupById = `action-groups/:id`,
+  DeleteTodayActionByActionGroup = `action-groups/:id/actions/today`,
 }
 
 @Controller(AjkTownApiVersion.V1)
@@ -43,5 +44,16 @@ export class ActionGroupController {
   async GetActionGroupById(@Req() req: Request, @Param('id') id: string) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
     return (await this.actionGroupService.getById(atd, id)).toResDTO(atd)
+  }
+
+  @Delete(ActionGroupControllerPath.DeleteTodayActionByActionGroup)
+  async deleteTodayActionByActionGroup(
+    @Req() req: Request,
+    @Param('id') id: string,
+  ) {
+    const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
+    return (await this.actionGroupService.deleteTodayAction(atd, id)).toResDTO(
+      atd,
+    )
   }
 }

--- a/src/services/action-group.service.ts
+++ b/src/services/action-group.service.ts
@@ -56,4 +56,15 @@ export class ActionGroupService {
 
     return ActionGroupDomain.fromId(id, this.actionGroupModel, this.actionModel)
   }
+
+  /**
+   * Delete every actions associated to the action group that is TODAY!
+   */
+  async deleteTodayAction(
+    atd: AccessTokenDomain,
+    actionGroupId: string,
+  ): Promise<ActionGroupDomain> {
+    const actionGroup = await this.getById(atd, actionGroupId)
+    return actionGroup.deleteTodayAction(atd, this.actionModel)
+  }
 }


### PR DESCRIPTION
# Background
This change allows users to delete their committed actions just in case if the following happens:
- Accidentally clicks `Done`

Deleting past commitments that is not today won't be provided, though even in the future.

## TODOs
- [x] Implement endpoint to delete actions committed today

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
