### PR TITLE
Action Group Now Returns Level 1 for Late Commitment

### DIFF
--- a/src/domains/action/action.domain.ts
+++ b/src/domains/action/action.domain.ts
@@ -26,6 +26,10 @@ export class ActionDomain extends DomainRoot {
     }
   }
 
+  get createdAtValue(): number {
+    return this.props.createdAt.valueOf()
+  }
+
   get yyyymmdd(): string {
     return this.props.yyyymmdd
   }


### PR DESCRIPTION
# Background
Action Group Now Returns Level 1 for Late Commitment

## TODOs
- [x] Implement so that it returns level 1 for late commitment

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [X] `Assignee` is set
- [X] `Labels` are set
- [x] `development` is linked if related issue exists
- [X] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
