### PR TITLE
Preference new props recentTags

### DIFF
--- a/src/domains/preference/index.interface.ts
+++ b/src/domains/preference/index.interface.ts
@@ -7,6 +7,7 @@ export interface IPreference extends DataBasicsDate {
   ownerId: string
   nativeLanguages: GlobalLanguageCode[]
   dictPreference: DictPreferenceDomain
+  recentTags: string[]
 }
 
 export interface IDictPreference {

--- a/src/schemas/preference.schema.ts
+++ b/src/schemas/preference.schema.ts
@@ -23,6 +23,12 @@ export class PreferenceProps {
 
   @Prop()
   selectedDictIds: string[] // i.e) ['google_en_en', 'naver_dictionary_ko_ko']
+
+  // store user's recent tags when the following happens:
+  //  - new tags are posted for newly-created words
+  //  - new tags are posted for already-created words
+  @Prop({ default: [] })
+  recentTags: string[]
 }
 
 export const PreferenceSchema = SchemaFactory.createForClass(PreferenceProps)


### PR DESCRIPTION
# Background
API wants to store user's recent tags when the following happens:
  - new tags are posted for newly-created words
  - new tags are posted for already-created words

To do the above, we first create the new props `recentTags` for preference.

## TODOs
- [x] Implement new props `recentTags` 

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
