### PR TITLE
Post word updates preference `recentTags`

### DIFF
--- a/src/services/word.service.ts
+++ b/src/services/word.service.ts
@@ -53,6 +53,7 @@ export class WordService {
       atd,
       this.wordModel,
       this.supportModel,
+      this.preferenceModel,
     )
   }
 


### PR DESCRIPTION
# Background
API wants to store user's recent tags when the following happens:
  - new tags are posted for newly-created words
  - new tags are posted for already-created words

To do the above, we first create the new props `recentTags` for preference.
This was handled in https://github.com/ajktown/api/pull/110

Next, we would like to import preference model for modules that will eventually need these.
This was handled in https://github.com/ajktown/api/pull/111

Now, when user actually creates a word, it should update preference's recentTags

## TODOs
- [x] Import preference model

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
