### PR TITLE
Update word updates preference `recentTags`

### DIFF
--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -194,6 +194,9 @@ export class WordDomain extends DomainRoot {
     if (atd.userId !== this.props.userId) {
       throw new UpdateForbiddenError(atd, `Word`)
     }
+    const existingWord = await wordModel.findById(this.id).exec()
+    const existingTags = existingWord ? existingWord.tag : []
+
     const updateWord = await wordModel
       .findByIdAndUpdate(
         this.id,
@@ -212,12 +215,14 @@ export class WordDomain extends DomainRoot {
       )
       .exec()
 
-    if (dto.tags && dto.tags.length > 0) {
+    const newTags = dto.tags.filter((tag) => !existingTags.includes(tag))
+
+    if (newTags.length > 0) {
       const preferenceDomain = await PreferenceDomain.fromMdbByAtd(
         atd,
         preferenceModel,
       )
-      await preferenceDomain.updateWithNewTags(atd, dto.tags, preferenceModel)
+      await preferenceDomain.updateWithNewTags(atd, newTags, preferenceModel)
     }
     return WordDomain.fromMdb(updateWord)
   }

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -194,7 +194,6 @@ export class WordDomain extends DomainRoot {
     if (atd.userId !== this.props.userId) {
       throw new UpdateForbiddenError(atd, `Word`)
     }
-    const existingTags = existingWord ? existingWord.tag : []
 
     const updateWord = await wordModel
       .findByIdAndUpdate(

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -194,7 +194,6 @@ export class WordDomain extends DomainRoot {
     if (atd.userId !== this.props.userId) {
       throw new UpdateForbiddenError(atd, `Word`)
     }
-    const existingWord = await wordModel.findById(this.id).exec()
     const existingTags = existingWord ? existingWord.tag : []
 
     const updateWord = await wordModel

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -213,7 +213,7 @@ export class WordDomain extends DomainRoot {
       )
       .exec()
 
-    const newTags = dto.tags.filter((tag) => !existingTags.includes(tag))
+    const newTags = dto.tags.filter((tag) => !this.props.tags.includes(tag))
 
     if (newTags.length > 0) {
       const preferenceDomain = await PreferenceDomain.fromMdbByAtd(

--- a/src/services/word.service.ts
+++ b/src/services/word.service.ts
@@ -89,7 +89,12 @@ export class WordService {
       throw new BadRequestError('Require at least one or more field to update!')
     }
     const wordDomain = await this.getById(id)
-    return wordDomain.updateWithPutDto(atd, dto, this.wordModel)
+    return wordDomain.updateWithPutDto(
+      atd,
+      dto,
+      this.wordModel,
+      this.preferenceModel,
+    )
   }
 
   async deleteById(id: string, atd: AccessTokenDomain): Promise<void> {


### PR DESCRIPTION
# Background
https://github.com/ajktown/api/issues/113

## TODOs
- [x] Implement so that API update preference's recentTags when user modifies tags of already-created word

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
