### PR TITLE
Fix bug where action group ids are not properly returned

### DIFF
--- a/src/domains/ritual/index.interface.ts
+++ b/src/domains/ritual/index.interface.ts
@@ -8,6 +8,7 @@
 //   ownerId: string
 // }
 
+// TODO: There should be only IRitual that actually requires actionGroupIds all the time.
 export interface IRitual {
   id: string
   ownerId: string

--- a/src/domains/ritual/parent-ritual.domain.ts
+++ b/src/domains/ritual/parent-ritual.domain.ts
@@ -4,6 +4,7 @@ import { IParentRitual } from './index.interface'
 import { ReadForbiddenError } from '@/errors/403/action_forbidden_errors/read-forbidden.error'
 import { ActionGroupDoc } from '@/schemas/action-group.schema'
 import { RitualDoc } from '@/schemas/ritual.schema'
+import { GetRitualByIdRes } from '@/responses/get-ritual.res'
 
 /**
  * ParentRitualDomain has both values:
@@ -57,19 +58,21 @@ export class ParentRitualDomain extends DomainRoot {
     })
   }
 
-  toResDTO(): IParentRitual {
-    return this.props
+  toResDTO(): GetRitualByIdRes {
+    return {
+      ritual: this.props,
+    }
   }
 
-  toDerivedResDTO(atd: AccessTokenDomain): IParentRitual {
+  toDerivedResDTO(atd: AccessTokenDomain): GetRitualByIdRes {
     if (atd.userId !== this.props.ownerId) {
       throw new ReadForbiddenError(atd, `ParentRitual`)
     }
-    return this.props
+    return this.toResDTO() // for now only
   }
 
-  // TODO: This should return IRitualShared
-  toSharedResDTO(): IParentRitual {
-    return this.props
+  // TODO: This should return GetSharedRitualsRes or something
+  toSharedResDTO(): GetRitualByIdRes {
+    return this.toResDTO() // for now only
   }
 }

--- a/src/domains/ritual/ritual-group.domain.ts
+++ b/src/domains/ritual/ritual-group.domain.ts
@@ -18,9 +18,9 @@ export class RitualGroupDomain extends DomainRoot {
   }
 
   // default is the first one always.
-  getDefault(): RitualDomain {
+  getDefault(): ParentRitualDomain {
     if (this.domains.length === 0) throw new NotExistOrNoPermissionError()
-    return RitualDomain.fromParentRitual(this.domains[0].toResDTO())
+    return this.domains[0]
   }
 
   /**
@@ -82,14 +82,14 @@ export class RitualGroupDomain extends DomainRoot {
 
   toResDTO(atd: AccessTokenDomain): GetRitualsRes {
     return {
-      rituals: this.domains.map((domain) => domain.toDerivedResDTO(atd)),
+      rituals: this.domains.map((domain) => domain.toDerivedResDTO(atd).ritual),
     }
   }
 
   // TODO: There should be Shared type for now
   toSharedResDTO(): GetRitualsRes {
     return {
-      rituals: this.domains.map((domain) => domain.toSharedResDTO()),
+      rituals: this.domains.map((domain) => domain.toSharedResDTO().ritual),
     }
   }
 }

--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -4,6 +4,7 @@ import { IRitual } from './index.interface'
 import { RitualModel } from '@/schemas/ritual.schema'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 import { GetRitualByIdRes } from '@/responses/get-ritual.res'
+import { ParentRitualDomain } from './parent-ritual.domain'
 
 /**
  * Ritual domain groups the ActionDomain
@@ -25,7 +26,8 @@ export class RitualDomain extends DomainRoot {
     return this.props.id
   }
 
-  static fromParentRitual(props: IRitual): RitualDomain {
+  static fromParentRitual(domain: ParentRitualDomain): RitualDomain {
+    const props = domain.toResDTO().ritual
     return new RitualDomain({
       id: props.id,
       ownerId: props.ownerId,

--- a/src/responses/get-ritual.res.ts
+++ b/src/responses/get-ritual.res.ts
@@ -1,9 +1,9 @@
-import { IParentRitual, IRitual } from '@/domains/ritual/index.interface'
+import { IParentRitual } from '@/domains/ritual/index.interface'
 
 export interface GetRitualsRes {
   rituals: IParentRitual[]
 }
 
 export interface GetRitualByIdRes {
-  ritual: IRitual
+  ritual: IParentRitual
 }

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -9,6 +9,7 @@ import { RitualGroupDomain } from '@/domains/ritual/ritual-group.domain'
 import { UserDomain } from '@/domains/user/user.domain'
 import { RitualModel, RitualProps } from '@/schemas/ritual.schema'
 import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
+import { ParentRitualDomain } from '@/domains/ritual/parent-ritual.domain'
 import { RitualDomain } from '@/domains/ritual/ritual.domain'
 
 @Injectable()
@@ -45,8 +46,13 @@ export class RitualService {
   async patchDefault(
     atd: AccessTokenDomain,
     dto: PatchRitualGroupBodyDTO,
-  ): Promise<RitualDomain> {
+  ): Promise<ParentRitualDomain> {
     const ritualGroup = await this.byAtd(atd)
-    return ritualGroup.getDefault().patch(dto, this.ritualModel)
+    await RitualDomain.fromParentRitual(ritualGroup.getDefault()).patch(
+      dto,
+      this.ritualModel,
+    )
+
+    return (await this.byAtd(atd)).getDefault()
   }
 }


### PR DESCRIPTION
# Background
Action group ids were missing some of the ids when using `PATCH /api/v1/rituals/default`

## TODOs
- [x] Fix the bug

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
