### PR TITLE
Fix where the api does not handle undefined `PutWordByIdBodyDTO`'s `tags`

### DIFF
--- a/src/domains/ritual/ritual.domain.ts
+++ b/src/domains/ritual/ritual.domain.ts
@@ -59,12 +59,6 @@ export class RitualDomain extends DomainRoot {
     })
   }
 
-  toResDTO(): GetRitualByIdRes {
-    return {
-      ritual: this.props,
-    }
-  }
-
   async patch(
     dto: PatchRitualGroupBodyDTO,
     model: RitualModel,

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -213,7 +213,9 @@ export class WordDomain extends DomainRoot {
       )
       .exec()
 
-    const newTags = dto.tags.filter((tag) => !this.props.tags.includes(tag))
+    const newTags = dto.tags
+      ? dto.tags.filter((tag) => !this.props.tags.includes(tag))
+      : []
 
     if (newTags.length > 0) {
       const preferenceDomain = await PreferenceDomain.fromMdbByAtd(


### PR DESCRIPTION
# Background
dto can be undefined, and therefore should use if else like the following:
![image](https://github.com/ajktown/api/assets/53258958/2b3de74a-da6e-4a44-9a39-1b9ac4a54f2c)


## TODOs
- [x] Fix the bug

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
