### PR TITLE
Apply `UnauthorizedException` => `UnidentifiedUserError` instead

### DIFF
--- a/src/domains/preference/index.interface.ts
+++ b/src/domains/preference/index.interface.ts
@@ -8,6 +8,7 @@ export interface IPreference extends DataBasicsDate {
   nativeLanguages: GlobalLanguageCode[]
   dictPreference: DictPreferenceDomain
   recentTags: string[]
+  gptApiKey: string
 }
 
 export interface IDictPreference {

--- a/src/domains/word/index.interface.ts
+++ b/src/domains/word/index.interface.ts
@@ -5,6 +5,7 @@ export interface ISharedWord {
   term: string
   pronunciation: string
   definition: string
+  subDefinition: string
   example: string
   exampleLink: string
   tags: string[]

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -29,6 +29,7 @@ export class WordDomain extends DomainRoot {
     props.term = props.term?.trim() || ''
     props.pronunciation = props.pronunciation?.trim() || ''
     props.definition = props.definition?.trim() || ''
+    props.subDefinition = props.subDefinition?.trim() || ''
     props.example = props.example?.trim() || ''
     props.exampleLink = props.exampleLink?.trim() || ''
     props.tags = this.intoTrimmedAndUniqueArray(props.tags) // every tag must be trimmed/unique all the time
@@ -62,6 +63,7 @@ export class WordDomain extends DomainRoot {
       term: dto.term,
       pronunciation: dto.pronunciation,
       definition: dto.definition,
+      subDefinition: dto.subDefinition,
       example: dto.example,
       exampleLink: dto.exampleLink,
       tags: dto.tags,
@@ -82,6 +84,7 @@ export class WordDomain extends DomainRoot {
       term: props.word,
       pronunciation: props.pronun,
       definition: props.meaning,
+      subDefinition: props.subDefinition,
       example: props.example,
       exampleLink: props.exampleLink,
       tags: props.tag,
@@ -141,6 +144,7 @@ export class WordDomain extends DomainRoot {
       word: this.props.term,
       pronun: this.props.pronunciation,
       meaning: this.props.definition,
+      subDefinition: this.props.subDefinition,
       example: this.props.example,
       exampleLink: this.props.exampleLink,
       tag: this.props.tags,
@@ -178,6 +182,7 @@ export class WordDomain extends DomainRoot {
       term: this.props.term,
       pronunciation: this.props.pronunciation,
       definition: this.props.definition,
+      subDefinition: this.props.subDefinition,
       example: this.props.example,
       exampleLink: this.props.exampleLink,
       tags: this.props.tags,
@@ -204,6 +209,7 @@ export class WordDomain extends DomainRoot {
           word: dto.term,
           pronun: dto.pronunciation,
           meaning: dto.definition,
+          subDefinition: dto.subDefinition,
           example: dto.example,
           exampleLink: dto.exampleLink,
           tag: dto.tags,

--- a/src/dto/get-word-query.dto.ts
+++ b/src/dto/get-word-query.dto.ts
@@ -57,6 +57,10 @@ export class GetWordQueryDTO
 
   @IsOptional()
   @IsString()
+  subDefinition: string
+
+  @IsOptional()
+  @IsString()
   example: string
 
   @IsOptional()

--- a/src/dto/post-word-body.dto.ts
+++ b/src/dto/post-word-body.dto.ts
@@ -26,6 +26,9 @@ export class PostWordBodyDTO {
   definition: string
 
   @IsString()
+  subDefinition: string
+
+  @IsString()
   example: string
 
   @IsString()

--- a/src/dto/put-preference.dto.ts
+++ b/src/dto/put-preference.dto.ts
@@ -1,5 +1,5 @@
 import { GlobalLanguageCode } from '@/global.interface'
-import { IsArray, IsOptional } from 'class-validator'
+import { IsArray, IsOptional, IsString } from 'class-validator'
 import { intoUniqueArray } from './index.validator'
 import { Transform } from 'class-transformer'
 
@@ -14,4 +14,8 @@ export class PutPreferenceDto {
   @IsArray()
   @IsOptional()
   selectedDictIds: string[]
+
+  @IsString()
+  @IsOptional()
+  gptApiKey: string
 }

--- a/src/dto/put-word-body.dto.ts
+++ b/src/dto/put-word-body.dto.ts
@@ -30,6 +30,10 @@ export class PutWordByIdBodyDTO {
 
   @IsString()
   @IsOptional()
+  subDefinition: string
+
+  @IsString()
+  @IsOptional()
   example: string
 
   @IsString()

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,11 +1,7 @@
 import { AccessTokenDomain } from '@/domains/auth/access-token.domain'
+import { UnidentifiedUserError } from '@/errors/401/unidentified-user.error'
 import { envLambda } from '@/lambdas/get-env.lambda'
-import {
-  Injectable,
-  Logger,
-  NestMiddleware,
-  UnauthorizedException,
-} from '@nestjs/common'
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 import { NextFunction, Request, Response } from 'express'
 
@@ -27,7 +23,7 @@ export class AuthMiddleware implements NestMiddleware {
     } catch (err) {
       this.logger.error(err)
 
-      return res.status(err.getStatus()).send(new UnauthorizedException())
+      return res.status(err.getStatus()).send(new UnidentifiedUserError())
     }
 
     next()

--- a/src/schemas/deprecated-word.schema.ts
+++ b/src/schemas/deprecated-word.schema.ts
@@ -43,7 +43,10 @@ export class WordProps {
   dateAdded: number // 1677483296006
 
   @Prop()
-  meaning: string
+  meaning: string // definition ("meaning" is deprecated expression from Wordy)
+
+  @Prop()
+  subDefinition: string // similar to meaning (or definition) please see details in word domain why subDefinition exists
 
   @Prop()
   pronun: string // pronunciation

--- a/src/schemas/preference.schema.ts
+++ b/src/schemas/preference.schema.ts
@@ -29,6 +29,9 @@ export class PreferenceProps {
   //  - new tags are posted for already-created words
   @Prop({ default: [] })
   recentTags: string[]
+
+  @Prop()
+  gptApiKey: string
 }
 
 export const PreferenceSchema = SchemaFactory.createForClass(PreferenceProps)


### PR DESCRIPTION
# Background
Apply `UnauthorizedException` => `UnidentifiedUserError` instead

## TODOs
- [x] Use custom created error `UnidentifiedUserError`, instead of nest js defined default error

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
