### PR TITLE
GPT Key Registable

### DIFF
--- a/src/domains/preference/index.interface.ts
+++ b/src/domains/preference/index.interface.ts
@@ -8,6 +8,7 @@ export interface IPreference extends DataBasicsDate {
   nativeLanguages: GlobalLanguageCode[]
   dictPreference: DictPreferenceDomain
   recentTags: string[]
+  gptApiKey: string
 }
 
 export interface IDictPreference {

--- a/src/dto/put-preference.dto.ts
+++ b/src/dto/put-preference.dto.ts
@@ -1,5 +1,5 @@
 import { GlobalLanguageCode } from '@/global.interface'
-import { IsArray, IsOptional } from 'class-validator'
+import { IsArray, IsOptional, IsString } from 'class-validator'
 import { intoUniqueArray } from './index.validator'
 import { Transform } from 'class-transformer'
 
@@ -14,4 +14,8 @@ export class PutPreferenceDto {
   @IsArray()
   @IsOptional()
   selectedDictIds: string[]
+
+  @IsString()
+  @IsOptional()
+  gptApiKey: string
 }

--- a/src/schemas/preference.schema.ts
+++ b/src/schemas/preference.schema.ts
@@ -29,6 +29,9 @@ export class PreferenceProps {
   //  - new tags are posted for already-created words
   @Prop({ default: [] })
   recentTags: string[]
+
+  @Prop()
+  gptApiKey: string
 }
 
 export const PreferenceSchema = SchemaFactory.createForClass(PreferenceProps)


### PR DESCRIPTION
# Background
`PreferenceDocs` now contains `gptKeyApi` to utilize chat gpt

## TODOs
- [x] Implement modifying gpt key

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
