### PR TITLE
API accepts dummy attribute for not performed action

### DIFF
--- a/src/controllers/action-group.controller.ts
+++ b/src/controllers/action-group.controller.ts
@@ -5,6 +5,7 @@ import { JwtService } from '@nestjs/jwt'
 import { AccessTokenDomain } from '@/domains/auth/access-token.domain'
 import { ActionGroupService } from '@/services/action-group.service'
 import { PostActionGroupDTO } from '@/dto/post-action-group.dto'
+import { PostActionBodyDTO } from '@/dto/post-action.dto'
 
 /**
  * Warning: Since Action Group is a huge domain, it only returns the ids of the action groups.
@@ -33,10 +34,14 @@ export class ActionGroupController {
   }
 
   @Post(ActionGroupControllerPath.PostActionByActionGroup)
-  async postActionByActionGroup(@Req() req: Request, @Param('id') id: string) {
+  async postActionByActionGroup(
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Body() dto: PostActionBodyDTO,
+  ) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
     return (
-      await this.actionGroupService.postActionByActionGroup(atd, id)
+      await this.actionGroupService.postActionByActionGroup(atd, id, dto)
     ).toResDTO(atd)
   }
 

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -22,6 +22,7 @@ import { ActionDoc, ActionModel, ActionProps } from '@/schemas/action.schema'
 import { NotExistOrNoPermissionError } from '@/errors/404/not-exist-or-no-permission.error'
 import { SupportedTimeZoneConst } from '@/constants/time-zone.const'
 import { NumberNotInRangeError } from '@/errors/400/index.num-not-in-range.error'
+import { PostActionBodyDTO } from '@/dto/post-action.dto'
 
 /**
  * ActionGroupDomain first contains only level 1~4 data.
@@ -176,6 +177,7 @@ export class ActionGroupDomain extends DomainRoot {
 
   async postAction(
     atd: AccessTokenDomain,
+    dto: PostActionBodyDTO,
     actionModel: ActionModel,
   ): Promise<this> {
     // check if is owned by the user
@@ -202,6 +204,7 @@ export class ActionGroupDomain extends DomainRoot {
     const docProps: ActionProps = {
       ownerId: this.props.ownerId,
       groupId: this.props.id,
+      isDummy: dto.isDummy || false,
     }
     const actionDomain = ActionDomain.fromMdb(
       this.props.timezone,

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -288,6 +288,7 @@ export class ActionGroupDomain extends DomainRoot {
       }
       //
       // if action committed but is late, it is level 1:
+      // TODO: This part has a bug where if a day passes, if is not handled
       if (this.props.closeAt.valueOf() < ad.createdAtValue) {
         actionsDerived.push(ad.toResDTO(1))
         continue

--- a/src/domains/action/action.domain.ts
+++ b/src/domains/action/action.domain.ts
@@ -51,6 +51,7 @@ export class ActionDomain extends DomainRoot {
       id: '',
       ownerId: '',
       groupId: groupId,
+      isDummy: false,
       createdAt: date,
       updatedAt: date,
     })
@@ -67,6 +68,7 @@ export class ActionDomain extends DomainRoot {
       id: '',
       ownerId: '',
       groupId: groupId,
+      isDummy: false,
       createdAt: new Date(props.dateAdded),
       // the action cannot be updated, but since it is from word domain,
       // we can simply set the dateAdded as updatedAt.
@@ -81,6 +83,7 @@ export class ActionDomain extends DomainRoot {
       id: doc.id,
       ownerId: doc.ownerId,
       groupId: doc.groupId,
+      isDummy: doc.isDummy,
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
     })

--- a/src/domains/action/index.interface.ts
+++ b/src/domains/action/index.interface.ts
@@ -6,6 +6,7 @@ export interface IActionInput extends DataBasicsDate {
   id: string
   ownerId: string
   groupId: string
+  isDummy: boolean
 }
 
 export interface IAction extends IActionInput {

--- a/src/dto/post-action.dto.ts
+++ b/src/dto/post-action.dto.ts
@@ -1,9 +1,10 @@
-import { IsString } from 'class-validator'
+import { IsBoolean, IsOptional } from 'class-validator'
+import { intoBoolean } from './index.validator'
+import { Transform } from 'class-transformer'
 
-export class PostActionDTO {
-  @IsString()
-  groupId: string
-
-  @IsString()
-  message: string
+export class PostActionBodyDTO {
+  @Transform(intoBoolean)
+  @IsBoolean()
+  @IsOptional()
+  isDummy: boolean
 }

--- a/src/schemas/action.schema.ts
+++ b/src/schemas/action.schema.ts
@@ -20,6 +20,10 @@ export class ActionProps {
 
   @Prop()
   groupId: string // the group of the action
+
+  // if action is not performed, even if it exists
+  @Prop()
+  isDummy: boolean
 }
 
 export const ActionSchema = SchemaFactory.createForClass(ActionProps)

--- a/src/services/action-group.service.ts
+++ b/src/services/action-group.service.ts
@@ -11,6 +11,7 @@ import {
 import { InjectModel } from '@nestjs/mongoose'
 import { ActionGroupFixedId } from '@/constants/action-group.const'
 import { ActionModel, ActionProps } from '@/schemas/action.schema'
+import { PostActionBodyDTO } from '@/dto/post-action.dto'
 
 @Injectable()
 export class ActionGroupService {
@@ -32,9 +33,10 @@ export class ActionGroupService {
   async postActionByActionGroup(
     atd: AccessTokenDomain,
     id: string,
+    dto: PostActionBodyDTO,
   ): Promise<ActionGroupDomain> {
     const actionGroup = await this.getById(atd, id)
-    return actionGroup.postAction(atd, this.actionModel)
+    return actionGroup.postAction(atd, dto, this.actionModel)
   }
 
   async getByUser(id: string): Promise<ActionGroupDomain> {


### PR DESCRIPTION
# Background
`POST /api/v1/action-groups/{id}` now supports a new dto attribute `isDummy` with the following behavior:
- `undefined`: the action posted under the action group with given {id} is a valid action committed
- `false`: the action posted under the action group with given {id} is a valid action committed
- `true`: the action posted under the action group with given {id} is not valid and cannot/won't be committed for the day.


## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
