### PR TITLE
Derived state

### DIFF
--- a/src/responses/get-action-groups.res.ts
+++ b/src/responses/get-action-groups.res.ts
@@ -5,6 +5,30 @@ type IsTodaySuccessful =
   | false // isPassed && !isTodayHandled
   | null // isPassed
 
+export type ActionGroupStateTime = `Early` | `OnTime` | `Late`
+export type ActionGroupStateCommitment =
+  | `Committed`
+  | `DummyCommitted`
+  | `NotCommitted`
+
+// | "EarlyCommitted"
+// | "EarlyDummyCommitted"
+// | "EarlyNotCommitted"
+// | "OnTimeCommitted"
+// | "OnTimeDummyCommitted"
+// | "OnTimeNotCommitted"
+// | "LateCommitted"
+// | "LateDummyCommitted"
+// | "LateNotCommitted"
+export type ActionGroupState =
+  `${ActionGroupStateTime}${ActionGroupStateCommitment}`
+
+interface ActionGroupDerivedState {
+  isOnTimeCommittable: boolean
+  isDummyCommittable: boolean
+  isLateCommittable: boolean
+  isDeletable: boolean
+}
 export interface GetActionGroupRes {
   props: IActionGroup
   actionsLength: number
@@ -14,4 +38,6 @@ export interface GetActionGroupRes {
   isPassed: boolean // check if time has already passed
   isTodaySuccessful: IsTodaySuccessful
   actions: IActionDerived[]
+  state: ActionGroupState
+  derivedState: ActionGroupDerivedState
 }


### PR DESCRIPTION
# Background
API now returns  `derivedState` with the following attribute:
```
{
    isOnTimeCommittable: this.isOnTimeCommittable,
    isDummyCommittable: this.isDummyCommittable,
    isLateCommittable: this.isLateCommittable,
    isDeletable: this.isDeletable,
}
```
FEs can use `derivedState` to determine UIs, rather than calculating their own.
 

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
