### PR TITLE
New body `isArchived` for `PATCH /api/v1/rituals/default`

### DIFF
--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -35,6 +35,6 @@ export class RitualController {
     @Body() dto: PatchRitualGroupBodyDTO,
   ) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    return (await this.ritualService.patchDefault(atd, dto)).toResDTO(undefined)
+    return (await this.ritualService.patchDefault(atd, dto)).toResDTO(dto)
   }
 }

--- a/src/domains/ritual/parent-ritual.domain.ts
+++ b/src/domains/ritual/parent-ritual.domain.ts
@@ -6,6 +6,7 @@ import { ActionGroupDoc } from '@/schemas/action-group.schema'
 import { RitualDoc } from '@/schemas/ritual.schema'
 import { GetRitualByIdRes } from '@/responses/get-ritual.res'
 import { GetRitualQueryDTO } from '@/dto/get-rituals-query.dto'
+import { PatchRitualGroupBodyDTO } from '@/dto/patch-ritual-group-body.dto'
 
 /**
  * ParentRitualDomain has both values:
@@ -70,8 +71,8 @@ export class ParentRitualDomain extends DomainRoot {
     })
   }
 
-  toResDTO(dto: GetRitualQueryDTO): GetRitualByIdRes {
-    if (!dto || dto.isArchived === undefined) {
+  toResDTO(dto: GetRitualQueryDTO | PatchRitualGroupBodyDTO): GetRitualByIdRes {
+    if (dto?.isArchived === undefined) {
       return {
         ritual: this.props,
       }

--- a/src/dto/patch-ritual-group-body.dto.ts
+++ b/src/dto/patch-ritual-group-body.dto.ts
@@ -1,6 +1,6 @@
 import { Transform } from 'class-transformer'
 import { IsArray, IsOptional } from 'class-validator'
-import { intoArray } from './index.validator'
+import { intoArray, intoBooleanOrUndefined } from './index.validator'
 
 // TODO: Name should be modifiable, but not yet supported, until multiple rituals are supported.
 export class PatchRitualGroupBodyDTO {
@@ -8,4 +8,8 @@ export class PatchRitualGroupBodyDTO {
   @IsOptional()
   @IsArray()
   actionGroupIds: string[]
+
+  @Transform(intoBooleanOrUndefined)
+  @IsOptional()
+  isArchived: undefined | boolean
 }


### PR DESCRIPTION
# Background
Endpoint `GET /api/v1/rituals/` already support a key `isArchived` in a body.
The `PATCH /api/v1/rituals/default` should do the same

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


