### PR TITLE
New Query `GetActionGroupByIdQueryDTO` for `/api/v1/action-groups/{id}`

### DIFF
--- a/src/dto/get-action-group-by-id-query.dto.ts
+++ b/src/dto/get-action-group-by-id-query.dto.ts
@@ -1,0 +1,16 @@
+import { IsNumber, IsOptional } from 'class-validator'
+import { intoNumber } from './index.validator'
+import { Transform } from 'class-transformer'
+
+/**
+ * Order in a priority queue.
+ * If both id and wordID given, id will be used.
+ */
+export class GetActionGroupByIdQueryDTO {
+  // undefined: get the latest for 365 days
+  // 2024: get all day for 2024
+  @Transform(intoNumber)
+  @IsNumber()
+  @IsOptional()
+  year: undefined | number
+}

--- a/src/lambdas/get-env.lambda.ts
+++ b/src/lambdas/get-env.lambda.ts
@@ -43,7 +43,11 @@ export const envLambda = {
   },
   getCorsOrigin: (): string[] => {
     const got = envLambda.get(SupportedEnvAttr.Cors)
-    if (!got) return ['http://localhost:3000,http://localhost:3100','http://localhost:3200'] // default value
+    if (!got)
+      return [
+        'http://localhost:3000,http://localhost:3100',
+        'http://localhost:3200',
+      ] // default value
 
     return got.split(',')
   },


### PR DESCRIPTION
# Background
https://github.com/ajktown/ConsistencyGPT/issues/8

I want the action groups to have selectable year at this point, before the end of this year.
API first must accept a query `year` for `/api/v1/action-groups/{id}`.


```
|   year    |                Meaning                |
|:---------:|:-------------------------------------:|
| undefined |      Returns the latest 365 days      |
|   2024    | Returns the latest 365 days from 2024 |
```

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [ ] The following has been handled:
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled


