### PR TITLE
feat: `api/v1/action-groups/:id` returns `firstYear`

### DIFF
--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -72,6 +72,7 @@ export class ActionGroupDomain extends DomainRoot {
     )
     this.props = {
       ...props,
+      firstYear: timeHandler.getYear(props.createdAt, props.timezone),
       openAt,
       closeAt,
       utc: '+9:00', // TODO: Get it from props.timezone. I dont know how at this point

--- a/src/domains/action/index.interface.ts
+++ b/src/domains/action/index.interface.ts
@@ -27,6 +27,7 @@ export interface IActionGroupInput extends DataBasicsDate {
 }
 
 export interface IActionGroup extends IActionGroupInput {
+  firstYear: number // first year that this action group is created
   openAt: Date
   closeAt: Date
   utc: string // i.e) +9:00 (timezone is private to shared data)

--- a/src/handlers/time.handler.ts
+++ b/src/handlers/time.handler.ts
@@ -26,6 +26,14 @@ export const timeHandler = {
 
     return ((now.valueOf() - convertedDate.valueOf()) / DAY_IN_MS) | 0
   },
+  /**
+   * Returns the year of the given date
+   * @returns year like 2022, 2023 etc
+   */
+  getYear: (givenDate: JsDateAccepter, timezone: string): number => {
+    return DateTime.fromJSDate(new Date(givenDate)).setZone(timezone).year
+  },
+
   /** Returns JS Start Date and End Date from given nDaysAgo */
   getDateFromDaysAgo: (nDaysAgo: number, timezone: string): [Date, Date] => {
     const nDaysAgoDate = DateTime.now()


### PR DESCRIPTION
# Background
Returns the `firstYear` in `api/v1/action-groups/:id` as the following:
```
{
    "props": {
        ...
        "firstYear": 2024,
    },
    ...
}
```

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


