### PR TITLE
refactor: for reusability

### DIFF
--- a/src/controllers/ritual.controller.ts
+++ b/src/controllers/ritual.controller.ts
@@ -35,6 +35,7 @@ export class RitualController {
     @Body() dto: PatchRitualGroupBodyDTO,
   ) {
     const atd = await AccessTokenDomain.fromReq(req, this.jwtService)
-    return (await this.ritualService.patchDefault(atd, dto)).toResDTO(dto)
+    await this.ritualService.patchDefault(atd, dto)
+    return (await this.ritualService.byAtd(atd)).toResDTO(atd, dto)
   }
 }

--- a/src/services/ritual.service.ts
+++ b/src/services/ritual.service.ts
@@ -48,16 +48,18 @@ export class RitualService {
     )
   }
 
+  /**
+   * This method will update for you, but won't return updated version.
+   * just simply use the byAtd or byUser according to your needs.
+   */
   async patchDefault(
     atd: AccessTokenDomain,
     dto: PatchRitualGroupBodyDTO,
-  ): Promise<ParentRitualDomain> {
+  ): Promise<void> {
     const ritualGroup = await this.byAtd(atd)
     await RitualDomain.fromParentRitual(ritualGroup.getDefault()).patch(
       dto,
       this.ritualModel,
     )
-
-    return (await this.byAtd(atd)).getDefault()
   }
 }


### PR DESCRIPTION
# Background
`PATCH /api/v1/rituals/default` now return the same format as the `GET /api/v1/rituals`

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


