### PR TITLE
feat: `GetActionGroupRes` now has a new derived field `streak`

### DIFF
--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -333,7 +333,7 @@ export class ActionGroupDomain extends DomainRoot {
       //
       // if no action committed in the first place, it is level 0:
       if (!ad) {
-        streak = 0 // reset streak as it is not committed
+        if (date !== end) streak = 0 // reset streak as it is not committed (BUT today is inclusive)
         actionsDerived.push(
           ActionDomain.fromEmpty(
             this.props.id,
@@ -345,7 +345,7 @@ export class ActionGroupDomain extends DomainRoot {
       }
       // if dummy, level 0:
       if (ad.isDummy) {
-        streak = 0 // reset streak as it is not committedstreaks = 0 // reset streak as it is not committed
+        streak = 0 // Dummy commit is considered no longer doable. So, reset streak.
         actionsDerived.push(ad.toResDTO(0))
         continue
       }

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -319,7 +319,7 @@ export class ActionGroupDomain extends DomainRoot {
     )
 
     const actionsDerived: IActionDerived[] = []
-
+    let streak = 0 // To motivate users to keep the streak
     for (
       let date = start;
       date <= end;
@@ -333,6 +333,7 @@ export class ActionGroupDomain extends DomainRoot {
       //
       // if no action committed in the first place, it is level 0:
       if (!ad) {
+        streak = 0 // reset streak as it is not committed
         actionsDerived.push(
           ActionDomain.fromEmpty(
             this.props.id,
@@ -344,9 +345,13 @@ export class ActionGroupDomain extends DomainRoot {
       }
       // if dummy, level 0:
       if (ad.isDummy) {
+        streak = 0 // reset streak as it is not committedstreaks = 0 // reset streak as it is not committed
         actionsDerived.push(ad.toResDTO(0))
         continue
       }
+
+      // From now on, action is done despite it is late:
+      streak += 1 // increment streak
 
       // if action committed but is late for that date, it is level 1:
       // make sure to subtract this.props.closeAt.valueOf() from the days behind
@@ -387,6 +392,7 @@ export class ActionGroupDomain extends DomainRoot {
 
     return {
       props: this.props,
+      streak,
       actionsLength: actionsDerived.length,
       isTodayHandled,
       // total counts is number of actions committed that is at least level 1 or higher

--- a/src/domains/action/action-group.domain.ts
+++ b/src/domains/action/action-group.domain.ts
@@ -333,7 +333,9 @@ export class ActionGroupDomain extends DomainRoot {
       //
       // if no action committed in the first place, it is level 0:
       if (!ad) {
-        if (date !== end) streak = 0 // reset streak as it is not committed (BUT today is inclusive)
+        // reset streak as it is not committed (BUT today is inclusive):
+        if (date.valueOf() !== end.valueOf()) streak = 0
+
         actionsDerived.push(
           ActionDomain.fromEmpty(
             this.props.id,
@@ -351,7 +353,7 @@ export class ActionGroupDomain extends DomainRoot {
       }
 
       // From now on, action is done despite it is late:
-      streak += 1 // increment streak
+      streak += 1
 
       // if action committed but is late for that date, it is level 1:
       // make sure to subtract this.props.closeAt.valueOf() from the days behind

--- a/src/responses/get-action-groups.res.ts
+++ b/src/responses/get-action-groups.res.ts
@@ -31,6 +31,7 @@ interface ActionGroupDerivedState {
 }
 export interface GetActionGroupRes {
   props: IActionGroup
+  streak: number
   actionsLength: number
   isTodayHandled: boolean
   totalCount: number


### PR DESCRIPTION
# Background
We want to keep motivating users not to lose their streak (falling off the wagon) by showing each action group's streak.
Humans often get motivated by not losing what they have, more than getting what they do not have.

## What's done
`GetActionGroupRes` now has a new derived field `streak`.
If user does multiple times, the streak goes up.

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


