### PR TITLE
Feat: Search Input now includes `subDefinition` of your word

### DIFF
--- a/src/factories/get-word-query.factory.ts
+++ b/src/factories/get-word-query.factory.ts
@@ -12,7 +12,7 @@ export class GetWordQueryFactory extends FactoryRoot<WordProps> {
     if (!query.searchInput) return {}
 
     return this.toObjectWithSearch(
-      ['word', 'pronun', 'meaning', 'example'],
+      ['word', 'pronun', 'meaning', 'subDefinition', 'example'],
       query.searchInput,
     )
   }


### PR DESCRIPTION
# Background
We want to include `subDefinition` of domain `WordDomain` as search result following:
![Screenshot 2025-02-01 at 9 50 17](https://github.com/user-attachments/assets/aef9d8d8-1159-49b2-81c1-961c5f4623a6)

## What's done
Implemented as the screenshot above

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


