### PR TITLE
Feat: New field `isPinned` for `Word` Schema

### DIFF
--- a/src/domains/word/index.interface.ts
+++ b/src/domains/word/index.interface.ts
@@ -16,5 +16,6 @@ export interface IWord extends ISharedWord, DataBasicsDate {
   userId: string
   semester: number
   isFavorite: boolean
+  isPinned: boolean
   isArchived: boolean
 }

--- a/src/domains/word/word-chunk.domain.ts
+++ b/src/domains/word/word-chunk.domain.ts
@@ -59,6 +59,12 @@ export class WordChunkDomain {
       )
         .sort((a, b) => b.dateAdded - a.dateAdded)
         .sort((a, b) => b.sem - a.sem)
+        .sort((a, b) => {
+          // pinned words must be on the top of the list all the time, by the rule of AJK Town
+          if (a.isPinned && !b.isPinned) return -1
+          if (!a.isPinned && b.isPinned) return 1
+          return 0
+        })
         .map((wordRaw) => WordDomain.fromMdb(wordRaw)),
       query,
     )

--- a/src/domains/word/word.domain.ts
+++ b/src/domains/word/word.domain.ts
@@ -30,6 +30,7 @@ export class WordDomain extends DomainRoot {
     props.pronunciation = props.pronunciation?.trim() || ''
     props.definition = props.definition?.trim() || ''
     props.subDefinition = props.subDefinition?.trim() || ''
+    props.isPinned = props.isPinned || false
     props.example = props.example?.trim() || ''
     props.exampleLink = props.exampleLink?.trim() || ''
     props.tags = this.intoTrimmedAndUniqueArray(props.tags) // every tag must be trimmed/unique all the time
@@ -81,6 +82,7 @@ export class WordDomain extends DomainRoot {
       languageCode: props.language as GlobalLanguageCode, // TODO: Write a type validator
       semester: props.sem,
       isFavorite: props.isFavorite,
+      isPinned: props.isPinned,
       term: props.word,
       pronunciation: props.pronun,
       definition: props.meaning,
@@ -141,6 +143,7 @@ export class WordDomain extends DomainRoot {
       language: this.props.languageCode,
       sem: this.props.semester,
       isFavorite: this.props.isFavorite,
+      isPinned: this.props.isPinned,
       word: this.props.term,
       pronun: this.props.pronunciation,
       meaning: this.props.definition,
@@ -206,6 +209,7 @@ export class WordDomain extends DomainRoot {
         {
           language: dto.languageCode,
           isFavorite: dto.isFavorite,
+          isPinned: dto.isPinned,
           word: dto.term,
           pronun: dto.pronunciation,
           meaning: dto.definition,

--- a/src/dto/get-word-query.dto.ts
+++ b/src/dto/get-word-query.dto.ts
@@ -11,10 +11,15 @@ import { GetReqDTORoot } from './index.root'
 import { Transform } from 'class-transformer'
 import { intoBoolean, intoNumber, intoArray } from './index.validator'
 
-type PrivateNotYetImplemented = 'tags' | 'createdAt' | 'updatedAt'
+type PrivateOmitted =
+  | 'tags' // Simply not implemented yet
+  | 'createdAt' // Simply not implemented yet
+  | 'updatedAt' // Simply not implemented yet
+  | 'isPinned' // The isPinned field is not acceptable as pinned word is always returned as the first word in the list.
+
 export class GetWordQueryDTO
   extends GetReqDTORoot
-  implements Omit<IWord, PrivateNotYetImplemented>
+  implements Omit<IWord, PrivateOmitted>
 {
   @IsString()
   @IsOptional()

--- a/src/dto/patch-word-body.dto.ts
+++ b/src/dto/patch-word-body.dto.ts
@@ -16,6 +16,11 @@ export class PatchWordByIdBodyDTO {
   @IsOptional()
   isFavorite: boolean
 
+  @Transform(intoBoolean)
+  @IsBoolean()
+  @IsOptional()
+  isPinned: boolean
+
   @IsString()
   @IsOptional()
   term: string

--- a/src/factories/get-word-query.factory.ts
+++ b/src/factories/get-word-query.factory.ts
@@ -23,27 +23,41 @@ export class GetWordQueryFactory extends FactoryRoot<WordProps> {
   ): FilterQuery<WordProps> {
     if (!atd.userId) throw new UnidentifiedUserError()
 
+    const queryBase: FilterQuery<WordProps>[] = [
+      {
+        ownerID: atd.userId,
+        ...this.getFilterForSearchInput(query),
+        ...this.toObject('_id', query.id),
+        ...this.toObject('language', query.languageCode),
+        ...this.toInObject('language', query.languageCodes),
+        ...this.toObject('sem', query.semester),
+        ...this.toObject('isFavorite', query.isFavorite),
+        ...this.toObject('word', query.term),
+        ...this.toObject('pronun', query.pronunciation),
+        ...this.toObject('meaning', query.definition),
+        ...this.toObject('example', query.example),
+        ...this.toNumRangeObjectByYear('dateAdded', query.year, atd),
+        ...this.toNumRangeObjectByDaysAgo('dateAdded', query.daysAgo, atd),
+        ...this.toNumRangeObjectByDaysAgoUntilToday(
+          'dateAdded',
+          query.daysAgoUntilToday,
+          atd,
+        ),
+        ...this.toInObject('tag', query.tags),
+        ...this.toObject('isArchived', query.isArchived),
+      },
+    ]
+
+    // user-pinned words always brought as the target data despite user query ONLY except when
+    // query length is 0.
+    // TODO: I think i need to some operation checks like:
+    // TODO: - favorite
+    // TODO: - tag
+    // TODO: - search input etc...
+    if (!query.searchInput) queryBase.push({ isPinned: true })
+
     return {
-      ownerID: atd.userId,
-      ...this.getFilterForSearchInput(query),
-      ...this.toObject('_id', query.id),
-      ...this.toObject('language', query.languageCode),
-      ...this.toInObject('language', query.languageCodes),
-      ...this.toObject('sem', query.semester),
-      ...this.toObject('isFavorite', query.isFavorite),
-      ...this.toObject('word', query.term),
-      ...this.toObject('pronun', query.pronunciation),
-      ...this.toObject('meaning', query.definition),
-      ...this.toObject('example', query.example),
-      ...this.toNumRangeObjectByYear('dateAdded', query.year, atd),
-      ...this.toNumRangeObjectByDaysAgo('dateAdded', query.daysAgo, atd),
-      ...this.toNumRangeObjectByDaysAgoUntilToday(
-        'dateAdded',
-        query.daysAgoUntilToday,
-        atd,
-      ),
-      ...this.toInObject('tag', query.tags),
-      ...this.toObject('isArchived', query.isArchived),
+      $or: queryBase,
     }
   }
 

--- a/src/factories/get-word-query.factory.ts
+++ b/src/factories/get-word-query.factory.ts
@@ -54,7 +54,7 @@ export class GetWordQueryFactory extends FactoryRoot<WordProps> {
     // TODO: - favorite
     // TODO: - tag
     // TODO: - search input etc...
-    if (!query.searchInput) queryBase.push({ isPinned: true })
+    if (!query.searchInput) queryBase.push({ ownerID: atd.userId, isPinned: true })
 
     return {
       $or: queryBase,

--- a/src/schemas/deprecated-word.schema.ts
+++ b/src/schemas/deprecated-word.schema.ts
@@ -34,6 +34,9 @@ export class WordProps {
   sem: number //231
 
   @Prop()
+  isPinned: boolean // this was introduced in Feb 2025. undefined isPinned is considered "not pinned" (aka false)
+
+  @Prop()
   isFavorite: boolean
 
   @Prop()


### PR DESCRIPTION
# Background
Sometimes, users find themselves wanting to focus on memorizing certain terms they learned years ago. However, even if they favorite a word, it gets pushed down over time since the favorite list sorts words by the earliest added.

It would be great to have a pin feature, allowing users to keep specific words at the top of their list at all times. This way, users can prioritize key terms while still using both the favorite and pin features based on their needs.

## What's done
Created a new field `isPinned` for `Word` Schema

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


